### PR TITLE
add bintray apt source line for laarid

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,6 +1,12 @@
 # GENERATED from Dockerfile.template. DO NOT EDIT.
 FROM vicamo/debian-linux-kernel-cross:@SUITE@-@ARCH@
 
+RUN echo "deb [allow-insecure=yes] http://dl.bintray.com/laarid/main stretch main" | \
+		tee /etc/apt/sources.list.d/bintray.list; \
+	(echo "Package: *"; echo "Pin: origin \"dl.bintray.com\""; echo "Pin-Priority: 1000") | \
+		tee /etc/apt/preferences.d/bintray.pref; \
+	apt-get update -qq
+
 ENV LAARID_USER=laarid
 ENV LAARID_HOME=/home/${LAARID_USER}
 

--- a/sid/amd64/Dockerfile
+++ b/sid/amd64/Dockerfile
@@ -1,6 +1,12 @@
 # GENERATED from Dockerfile.template. DO NOT EDIT.
 FROM vicamo/debian-linux-kernel-cross:sid-amd64
 
+RUN echo "deb [allow-insecure=yes] http://dl.bintray.com/laarid/main stretch main" | \
+		tee /etc/apt/sources.list.d/bintray.list; \
+	(echo "Package: *"; echo "Pin: origin \"dl.bintray.com\""; echo "Pin-Priority: 1000") | \
+		tee /etc/apt/preferences.d/bintray.pref; \
+	apt-get update -qq
+
 ENV LAARID_USER=laarid
 ENV LAARID_HOME=/home/${LAARID_USER}
 

--- a/sid/arm64/Dockerfile
+++ b/sid/arm64/Dockerfile
@@ -1,6 +1,12 @@
 # GENERATED from Dockerfile.template. DO NOT EDIT.
 FROM vicamo/debian-linux-kernel-cross:sid-arm64
 
+RUN echo "deb [allow-insecure=yes] http://dl.bintray.com/laarid/main stretch main" | \
+		tee /etc/apt/sources.list.d/bintray.list; \
+	(echo "Package: *"; echo "Pin: origin \"dl.bintray.com\""; echo "Pin-Priority: 1000") | \
+		tee /etc/apt/preferences.d/bintray.pref; \
+	apt-get update -qq
+
 ENV LAARID_USER=laarid
 ENV LAARID_HOME=/home/${LAARID_USER}
 

--- a/sid/armel/Dockerfile
+++ b/sid/armel/Dockerfile
@@ -1,6 +1,12 @@
 # GENERATED from Dockerfile.template. DO NOT EDIT.
 FROM vicamo/debian-linux-kernel-cross:sid-armel
 
+RUN echo "deb [allow-insecure=yes] http://dl.bintray.com/laarid/main stretch main" | \
+		tee /etc/apt/sources.list.d/bintray.list; \
+	(echo "Package: *"; echo "Pin: origin \"dl.bintray.com\""; echo "Pin-Priority: 1000") | \
+		tee /etc/apt/preferences.d/bintray.pref; \
+	apt-get update -qq
+
 ENV LAARID_USER=laarid
 ENV LAARID_HOME=/home/${LAARID_USER}
 

--- a/sid/armhf/Dockerfile
+++ b/sid/armhf/Dockerfile
@@ -1,6 +1,12 @@
 # GENERATED from Dockerfile.template. DO NOT EDIT.
 FROM vicamo/debian-linux-kernel-cross:sid-armhf
 
+RUN echo "deb [allow-insecure=yes] http://dl.bintray.com/laarid/main stretch main" | \
+		tee /etc/apt/sources.list.d/bintray.list; \
+	(echo "Package: *"; echo "Pin: origin \"dl.bintray.com\""; echo "Pin-Priority: 1000") | \
+		tee /etc/apt/preferences.d/bintray.pref; \
+	apt-get update -qq
+
 ENV LAARID_USER=laarid
 ENV LAARID_HOME=/home/${LAARID_USER}
 

--- a/sid/hurd-i386/Dockerfile
+++ b/sid/hurd-i386/Dockerfile
@@ -1,6 +1,12 @@
 # GENERATED from Dockerfile.template. DO NOT EDIT.
 FROM vicamo/debian-linux-kernel-cross:sid-hurd-i386
 
+RUN echo "deb [allow-insecure=yes] http://dl.bintray.com/laarid/main stretch main" | \
+		tee /etc/apt/sources.list.d/bintray.list; \
+	(echo "Package: *"; echo "Pin: origin \"dl.bintray.com\""; echo "Pin-Priority: 1000") | \
+		tee /etc/apt/preferences.d/bintray.pref; \
+	apt-get update -qq
+
 ENV LAARID_USER=laarid
 ENV LAARID_HOME=/home/${LAARID_USER}
 

--- a/sid/i386/Dockerfile
+++ b/sid/i386/Dockerfile
@@ -1,6 +1,12 @@
 # GENERATED from Dockerfile.template. DO NOT EDIT.
 FROM vicamo/debian-linux-kernel-cross:sid-i386
 
+RUN echo "deb [allow-insecure=yes] http://dl.bintray.com/laarid/main stretch main" | \
+		tee /etc/apt/sources.list.d/bintray.list; \
+	(echo "Package: *"; echo "Pin: origin \"dl.bintray.com\""; echo "Pin-Priority: 1000") | \
+		tee /etc/apt/preferences.d/bintray.pref; \
+	apt-get update -qq
+
 ENV LAARID_USER=laarid
 ENV LAARID_HOME=/home/${LAARID_USER}
 

--- a/sid/kfreebsd-amd64/Dockerfile
+++ b/sid/kfreebsd-amd64/Dockerfile
@@ -1,6 +1,12 @@
 # GENERATED from Dockerfile.template. DO NOT EDIT.
 FROM vicamo/debian-linux-kernel-cross:sid-kfreebsd-amd64
 
+RUN echo "deb [allow-insecure=yes] http://dl.bintray.com/laarid/main stretch main" | \
+		tee /etc/apt/sources.list.d/bintray.list; \
+	(echo "Package: *"; echo "Pin: origin \"dl.bintray.com\""; echo "Pin-Priority: 1000") | \
+		tee /etc/apt/preferences.d/bintray.pref; \
+	apt-get update -qq
+
 ENV LAARID_USER=laarid
 ENV LAARID_HOME=/home/${LAARID_USER}
 

--- a/sid/kfreebsd-i386/Dockerfile
+++ b/sid/kfreebsd-i386/Dockerfile
@@ -1,6 +1,12 @@
 # GENERATED from Dockerfile.template. DO NOT EDIT.
 FROM vicamo/debian-linux-kernel-cross:sid-kfreebsd-i386
 
+RUN echo "deb [allow-insecure=yes] http://dl.bintray.com/laarid/main stretch main" | \
+		tee /etc/apt/sources.list.d/bintray.list; \
+	(echo "Package: *"; echo "Pin: origin \"dl.bintray.com\""; echo "Pin-Priority: 1000") | \
+		tee /etc/apt/preferences.d/bintray.pref; \
+	apt-get update -qq
+
 ENV LAARID_USER=laarid
 ENV LAARID_HOME=/home/${LAARID_USER}
 

--- a/sid/mips/Dockerfile
+++ b/sid/mips/Dockerfile
@@ -1,6 +1,12 @@
 # GENERATED from Dockerfile.template. DO NOT EDIT.
 FROM vicamo/debian-linux-kernel-cross:sid-mips
 
+RUN echo "deb [allow-insecure=yes] http://dl.bintray.com/laarid/main stretch main" | \
+		tee /etc/apt/sources.list.d/bintray.list; \
+	(echo "Package: *"; echo "Pin: origin \"dl.bintray.com\""; echo "Pin-Priority: 1000") | \
+		tee /etc/apt/preferences.d/bintray.pref; \
+	apt-get update -qq
+
 ENV LAARID_USER=laarid
 ENV LAARID_HOME=/home/${LAARID_USER}
 

--- a/sid/mips64el/Dockerfile
+++ b/sid/mips64el/Dockerfile
@@ -1,6 +1,12 @@
 # GENERATED from Dockerfile.template. DO NOT EDIT.
 FROM vicamo/debian-linux-kernel-cross:sid-mips64el
 
+RUN echo "deb [allow-insecure=yes] http://dl.bintray.com/laarid/main stretch main" | \
+		tee /etc/apt/sources.list.d/bintray.list; \
+	(echo "Package: *"; echo "Pin: origin \"dl.bintray.com\""; echo "Pin-Priority: 1000") | \
+		tee /etc/apt/preferences.d/bintray.pref; \
+	apt-get update -qq
+
 ENV LAARID_USER=laarid
 ENV LAARID_HOME=/home/${LAARID_USER}
 

--- a/sid/mipsel/Dockerfile
+++ b/sid/mipsel/Dockerfile
@@ -1,6 +1,12 @@
 # GENERATED from Dockerfile.template. DO NOT EDIT.
 FROM vicamo/debian-linux-kernel-cross:sid-mipsel
 
+RUN echo "deb [allow-insecure=yes] http://dl.bintray.com/laarid/main stretch main" | \
+		tee /etc/apt/sources.list.d/bintray.list; \
+	(echo "Package: *"; echo "Pin: origin \"dl.bintray.com\""; echo "Pin-Priority: 1000") | \
+		tee /etc/apt/preferences.d/bintray.pref; \
+	apt-get update -qq
+
 ENV LAARID_USER=laarid
 ENV LAARID_HOME=/home/${LAARID_USER}
 

--- a/sid/powerpc/Dockerfile
+++ b/sid/powerpc/Dockerfile
@@ -1,6 +1,12 @@
 # GENERATED from Dockerfile.template. DO NOT EDIT.
 FROM vicamo/debian-linux-kernel-cross:sid-powerpc
 
+RUN echo "deb [allow-insecure=yes] http://dl.bintray.com/laarid/main stretch main" | \
+		tee /etc/apt/sources.list.d/bintray.list; \
+	(echo "Package: *"; echo "Pin: origin \"dl.bintray.com\""; echo "Pin-Priority: 1000") | \
+		tee /etc/apt/preferences.d/bintray.pref; \
+	apt-get update -qq
+
 ENV LAARID_USER=laarid
 ENV LAARID_HOME=/home/${LAARID_USER}
 

--- a/sid/ppc64el/Dockerfile
+++ b/sid/ppc64el/Dockerfile
@@ -1,6 +1,12 @@
 # GENERATED from Dockerfile.template. DO NOT EDIT.
 FROM vicamo/debian-linux-kernel-cross:sid-ppc64el
 
+RUN echo "deb [allow-insecure=yes] http://dl.bintray.com/laarid/main stretch main" | \
+		tee /etc/apt/sources.list.d/bintray.list; \
+	(echo "Package: *"; echo "Pin: origin \"dl.bintray.com\""; echo "Pin-Priority: 1000") | \
+		tee /etc/apt/preferences.d/bintray.pref; \
+	apt-get update -qq
+
 ENV LAARID_USER=laarid
 ENV LAARID_HOME=/home/${LAARID_USER}
 

--- a/sid/s390x/Dockerfile
+++ b/sid/s390x/Dockerfile
@@ -1,6 +1,12 @@
 # GENERATED from Dockerfile.template. DO NOT EDIT.
 FROM vicamo/debian-linux-kernel-cross:sid-s390x
 
+RUN echo "deb [allow-insecure=yes] http://dl.bintray.com/laarid/main stretch main" | \
+		tee /etc/apt/sources.list.d/bintray.list; \
+	(echo "Package: *"; echo "Pin: origin \"dl.bintray.com\""; echo "Pin-Priority: 1000") | \
+		tee /etc/apt/preferences.d/bintray.pref; \
+	apt-get update -qq
+
 ENV LAARID_USER=laarid
 ENV LAARID_HOME=/home/${LAARID_USER}
 


### PR DESCRIPTION
Packages we built from source packages linux and linux-latest will retain their version as officially released by Debian so that we may reuse other kernel packages without unexpected conflicts. Therefore, packages in laarid's bintray is pinned with a higher priority here.